### PR TITLE
Fix session storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ app.use(bodyParser.json());
 app.use(
   session({
     cookie: { maxAge: 60000 },
-    saveUninitialized: true,
+    saveUninitialized: false,
     resave: true,
     secret: "monster hommus"
   })


### PR DESCRIPTION
saveUnintialized set to true saves unintialized sessions(new session without modification) to store, overriding user session thus removing it from the session. 